### PR TITLE
Bump Stream SDK to 5.12.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-streamChatSDK = "5.11.7"
+streamChatSDK = "5.12.0"
 streamLog = "1.1.3"
 sealedx = "1.0.0"
 landscapist = "2.1.0"


### PR DESCRIPTION
### 🎯 Goal
Bump Stream SDK to 5.12.0.