### PR TITLE
remove unnecessary ioDispatcher when calling await

### DIFF
--- a/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessageTopBar.kt
+++ b/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessageTopBar.kt
@@ -45,7 +45,6 @@ import io.getstream.whatsappclone.designsystem.theme.WhatsAppCloneComposeTheme
 import io.getstream.whatsappclone.navigation.AppComposeNavigator
 import io.getstream.whatsappclone.navigation.WhatsAppCloneComposeNavigator
 import io.getstream.whatsappclone.uistate.WhatsAppMessageUiState
-import kotlinx.coroutines.Dispatchers
 
 @Composable
 fun WhatsAppMessageTopBar(
@@ -142,7 +141,7 @@ private fun WhatsAppMessageUserInfo(
 private fun WhatsAppTopBarPreview() {
   WhatsAppCloneComposeTheme {
     WhatsAppMessageTopBar(
-      WhatsAppMessagesViewModel(Dispatchers.IO, ChatClient.instance()),
+      WhatsAppMessagesViewModel(ChatClient.instance()),
       WhatsAppCloneComposeNavigator()
     )
   }
@@ -153,7 +152,7 @@ private fun WhatsAppTopBarPreview() {
 private fun WhatsAppTopBarDarkPreview() {
   WhatsAppCloneComposeTheme(darkTheme = true) {
     WhatsAppMessageTopBar(
-      WhatsAppMessagesViewModel(Dispatchers.IO, ChatClient.instance()),
+      WhatsAppMessagesViewModel(ChatClient.instance()),
       WhatsAppCloneComposeNavigator()
     )
   }

--- a/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessagesViewModel.kt
+++ b/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessagesViewModel.kt
@@ -22,18 +22,14 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.utils.onError
 import io.getstream.chat.android.client.utils.onSuccess
-import io.getstream.whatsappclone.network.Dispatcher
-import io.getstream.whatsappclone.network.WhatsAppDispatchers
 import io.getstream.whatsappclone.uistate.WhatsAppMessageUiState
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WhatsAppMessagesViewModel @Inject constructor(
-  @Dispatcher(WhatsAppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
   private val chatClient: ChatClient
 ) : ViewModel() {
   private val messageMutableUiState =
@@ -47,7 +43,7 @@ class WhatsAppMessagesViewModel @Inject constructor(
   }
 
   private fun fetchChannel(channelId: String) {
-    viewModelScope.launch(ioDispatcher) {
+    viewModelScope.launch {
       val result = chatClient.channel(channelId).watch().await()
       result.onSuccess {
         messageMutableUiState.value = WhatsAppMessageUiState.Success(result.data())


### PR DESCRIPTION
### 🎯 Goal
As specified in stream-chat-android documentation, _await_ function is safe to be called from the main thread.

> Awaits the result of this [Call] in a suspending way, asynchronously.
> Safe to call from any CoroutineContext.

I think this could avoid confusion when trying to learn how to use stream-chat.

### 🛠 Implementation details
Removed _ioDispatcher_ from _WhatsAppMessagesViewModel_ when fetching channel.

### ✍️ Explain examples
```
  private fun fetchChannel(channelId: String) {
    viewModelScope.launch {
      val result = chatClient.channel(channelId).watch().await()
      result.onSuccess {
        messageMutableUiState.value = WhatsAppMessageUiState.Success(result.data())
      }.onError {
        messageMutableUiState.value = WhatsAppMessageUiState.Error
      }
    }
  }
```