### PR TITLE
Remove TopBar dependency on ViewModel

### DIFF
--- a/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessageTopBar.kt
+++ b/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessageTopBar.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.skydoves.landscapist.animation.crossfade.CrossfadePlugin
 import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.glide.GlideImage
@@ -43,9 +42,8 @@ import io.getstream.whatsappclone.uistate.WhatsAppMessageUiState
 
 @Composable
 fun WhatsAppMessageTopBar(
-  channelId: String,
-  whatsAppMessagesViewModel: WhatsAppMessagesViewModel = hiltViewModel(),
   messageUiState: WhatsAppMessageUiState,
+  navigateToVideoCall: (Boolean) -> Unit,
   onBackClick: () -> Unit
 ) {
   TopAppBar(
@@ -70,7 +68,7 @@ fun WhatsAppMessageTopBar(
         modifier = Modifier
           .size(26.dp)
           .clickable {
-            whatsAppMessagesViewModel.navigateToVideoCall(channelId = channelId, videoCall = true)
+            navigateToVideoCall(true)
           },
         imageVector = WhatsAppIcons.Video,
         tint = MaterialTheme.colorScheme.tertiary,
@@ -83,7 +81,7 @@ fun WhatsAppMessageTopBar(
         modifier = Modifier
           .size(26.dp)
           .clickable {
-            whatsAppMessagesViewModel.navigateToVideoCall(channelId = channelId, videoCall = false)
+            navigateToVideoCall(false)
           },
         imageVector = WhatsAppIcons.Call,
         tint = MaterialTheme.colorScheme.tertiary,
@@ -142,8 +140,8 @@ private fun WhatsAppMessageUserInfo(
 private fun WhatsAppTopBarPreview() {
   WhatsAppCloneComposeTheme {
     WhatsAppMessageTopBar(
-      channelId = "",
       messageUiState = WhatsAppMessageUiState.Loading,
+      navigateToVideoCall = {},
       onBackClick = {}
     )
   }
@@ -154,8 +152,8 @@ private fun WhatsAppTopBarPreview() {
 private fun WhatsAppTopBarDarkPreview() {
   WhatsAppCloneComposeTheme(darkTheme = true) {
     WhatsAppMessageTopBar(
-      channelId = "",
       messageUiState = WhatsAppMessageUiState.Loading,
+      navigateToVideoCall = {},
       onBackClick = {}
     )
   }

--- a/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessages.kt
+++ b/features/chats/src/main/kotlin/io/getstream/whatsappclone/chats/messages/WhatsAppMessages.kt
@@ -38,8 +38,10 @@ fun WhatsAppMessages(
   WhatsAppChatTheme {
     Column(Modifier.fillMaxSize()) {
       WhatsAppMessageTopBar(
-        channelId = channelId,
         messageUiState = messageUiState,
+        navigateToVideoCall = {
+          whatsAppMessagesViewModel.navigateToVideoCall(channelId, videoCall = it)
+        },
         onBackClick = { whatsAppMessagesViewModel.handleEvents(WhatsAppMessageEvent.NavigateUp) }
       )
 


### PR DESCRIPTION
### 🎯 Goal
Fix "MessageTopBar Preview is broken" issue https://github.com/GetStream/whatsApp-clone-compose/issues/192

### 🛠 Implementation details
`@Composable WhatsAppMessageTopBar` takes `WhatsAppMessagesViewModel` as a parameter and since we cannot instantiate ViewModel in Previews, it doesn't render the Preview.

#### Before
![Screenshot 2024-03-17 at 4 15 03 PM](https://github.com/GetStream/whatsApp-clone-compose/assets/43310446/e21318e6-3ce4-46d2-9c73-42045afcb536)


#### After
![Screenshot 2024-03-17 at 4 14 04 PM](https://github.com/GetStream/whatsApp-clone-compose/assets/43310446/216435bc-ad38-497b-b089-448235dcd9d3)

### ✍️ Explain examples
Setup a callback to trigger a function in ViewModel instead (takes `videoCall` flag as a param to be passed onto VM).
```
@Composable
fun WhatsAppMessageTopBar(
  .
  navigateToVideoCall: (Boolean) -> Unit,
  .
)
```