### PR TITLE
Fix emoji code for "Dislike" reaction

### DIFF
--- a/features/video/src/main/kotlin/io/getstream/whatsappclone/video/ReactionsMenu.kt
+++ b/features/video/src/main/kotlin/io/getstream/whatsappclone/video/ReactionsMenu.kt
@@ -73,7 +73,7 @@ private object DefaultReactionsMenuData {
     ReactionItemData("Fireworks", ":fireworks:"),
     ReactionItemData("Wave", ":hello:"),
     ReactionItemData("Like", ":raise-hand:"),
-    ReactionItemData("Dislike", ":hate:"),
+    ReactionItemData("Dislike", ":dislike:"),
     ReactionItemData("Smile", ":smile:"),
     ReactionItemData("Heart", ":heart:")
   )


### PR DESCRIPTION
There is no mapped emoji available for :hate: in `ReactionMapper.` so the emoji fallbacks to text only.

### 🎯 Goal

#### Before
![Screenshot 2024-03-17 at 4 49 51 PM](https://github.com/GetStream/whatsApp-clone-compose/assets/43310446/0fdb7782-cd47-4d12-bca3-cd0571d3278d)

#### After
![Screenshot 2024-03-17 at 4 49 46 PM](https://github.com/GetStream/whatsApp-clone-compose/assets/43310446/a46f2518-d6dd-440c-9a41-c723d04a54a8)


### 🛠 Implementation details
Replaced ":hate:" usage with ":dislike:" as it is available in `ReactionMapper`

```
fun defaultReactionMapper(): ReactionMapper {
            return ReactionMapper { emojiCode ->
                when (emojiCode) {
                    ":fireworks:", ":tada:" -> "\uD83C\uDF89"
                    ":raise-hand:" -> "✋"
                    ":like:" -> "\uD83D\uDC4D"
                    ":dislike:" -> "\uD83D\uDC4E"
                    ":hello:" -> "\uD83D\uDC4B"
                    ":smile:" -> "\uD83D\uDE42"
                    ":heart:" -> "\u2665"
                    else -> emojiCode
                }
            }
        }
```