### PR TITLE
Migration kotlinOptions to compilerOptions

### DIFF
--- a/build-logic/convention/src/main/kotlin/io/getstream/whatsappclone/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/io/getstream/whatsappclone/KotlinAndroid.kt
@@ -4,7 +4,11 @@ import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * Configure base Kotlin with Android options
@@ -28,26 +32,26 @@ internal fun Project.configureKotlinAndroid(
       abortOnError = false
     }
 
-    kotlinOptions {
-      // Treat all Kotlin warnings as errors (disabled by default)
-      allWarningsAsErrors = properties["warningsAsErrors"] as? Boolean ?: false
+    tasks.withType<KotlinCompile>().configureEach {
+      compilerOptions {
+        val warningsAsErrors: String? by project
+        // Treat all Kotlin warnings as errors (disabled by default)
+        allWarningsAsErrors.set(warningsAsErrors.toBoolean())
 
-      freeCompilerArgs = freeCompilerArgs + listOf(
-        "-opt-in=kotlin.RequiresOptIn",
-        // Enable experimental coroutines APIs, including Flow
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        // Enable experimental compose APIs
-        "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi",
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
-      )
+        freeCompilerArgs.addAll(
+          listOf(
+            "-opt-in=kotlin.RequiresOptIn",
+            // Enable experimental coroutines APIs, including Flow
+            "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+            // Enable experimental compose APIs
+            "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi",
+            "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+            "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
+          )
+        )
 
-      // Set JVM target to 11
-      jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget.set(JvmTarget.JVM_17)
+      }
     }
   }
-}
-
-fun CommonExtension<*, *, *, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
-  (this as ExtensionAware).extensions.configure("kotlinOptions", block)
 }


### PR DESCRIPTION
### 🎯 Goal
<img src="https://github.com/user-attachments/assets/e6129fd7-397f-4edb-961f-f6af438f99d3" width=600>

According to the [official Kotlin documentation](https://kotlinlang.org/docs/whatsnew20.html#deprecated-old-ways-of-defining-compiler-options), **`kotlinOptions` has been deprecated**, and it is recommended to **migrate to `compilerOptions`**. Therefore, the goal of this task is to migrate the deprecated `kotlinOptions` in the Gradle build scripts to the new `compilerOptions`.


### 🛠 Implementation details

Removed the usage of the extension function related to `kotlinOptions`, namely `kotlinOptions(block: KotlinJvmOptions.() -> Unit)`.

```kotlin
fun CommonExtension<*, *, *, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
  (this as ExtensionAware).extensions.configure("kotlinOptions", block)
}
```

Applied `compilerOptions` to all Kotlin compile tasks by utilizing `tasks.withType<KotlinCompile>()`. This approach ensures that the updated compiler configurations are consistently applied across all modules and source sets in the project.

```kotlin
tasks.withType<KotlinCompile>().configureEach {
    compilerOptions {
        // Compiler options configuration
    }
}
```