### PR TITLE
[APPSEC-1] Upgrade cache action from v2 to v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
We can safely bump cache to v4. GitHub kept the exact same input schema from v2 → v3 → v4. v4 is just faster, more reliable, and fixes rare race conditions.

### 🎯 Goal
 
All builds has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
 
